### PR TITLE
Fix multi VM handling of Out-AzureUtilRdcManRdgFile cmdlet

### DIFF
--- a/AzureUtil/RdcManRdgFile.psm1
+++ b/AzureUtil/RdcManRdgFile.psm1
@@ -69,10 +69,10 @@ function Out-AzureUtilRdcManRdgFile
             $groupElm = CreateGroupElement -XmlDoc $xmlDoc -GroupName $group.Name
             [void] $xmlDoc.RDCMan.file.AppendChild($groupElm)
 
-            $group |
+            $group.Group |
                 ForEach-Object -Process {
 
-                    $connectionInfo = $_.Group
+                    $connectionInfo = $_
 
                     # Create a new server element as child of the group element.
                     $param = @{


### PR DESCRIPTION
The Out-AzureUtilRdcManRdgFile cmlet is fail if the target resource gourp has multi virtual machine. This commit fixed above issue.